### PR TITLE
Use sonar.token instead of login

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -67,8 +67,8 @@ public class SonarFacade {
         this.gitLabPluginConfiguration = gitLabPluginConfiguration;
 
         HttpConnector httpConnector = HttpConnector.newBuilder().url(gitLabPluginConfiguration.baseUrl())
-                .credentials(settings.get(CoreProperties.LOGIN).orElse(null), settings.get(CoreProperties.PASSWORD).orElse(null)).build();
-
+                .credentials(settings.get("sonar.token").orElse(null), settings.get(CoreProperties.PASSWORD).orElse(null)).build();
+        
         wsClient = WsClientFactories.getDefault().newClient(httpConnector);
     }
 


### PR DESCRIPTION
CoreProperties.LOGIN is not supported since 2025.1, so we must use   sonar.token instead (CoreProperties.TOKEN doesn't exist in sonar-plugin-api)